### PR TITLE
Install WP automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ This project requires that you build Linux binaries which can be deployed to a s
   1. Create unique WordPress keys for your site (must be in the same directory as `default-app-config.nix`):
     * `curl https://api.wordpress.org/secret-key/1.1/salt/ > wordpress-keys.php.secret`.
   2. Configure your site by editing `default-app-config.nix`.
+    * For automatic install using WP-CLI, use `autoInstall = true;`.
+      * Copy `./wordpress-admin.keys.nix.sample` to `./wordpress-admin.keys.nix`. Replace `...` with your credentials.
     * For a traditional install where WordPress is entirely managed by the admin panel, use `freezeWordPress = false;`.
     * To have Nix manage themes but not plugins, you can use `freezeWordPress = true; freezeThemes = true; freezePlugins = false;`.
     * When WordPress is frozen (i.e. managed by Nix), use `wordpress.nix` to govern the installed version.

--- a/default-app-config.nix
+++ b/default-app-config.nix
@@ -10,6 +10,7 @@ in lib.makeExtensible (self: {
   name        = "wordpress-app";
 
   description = "A Wordpress Site";    # Brief, one-line description or title
+  tagline     = "Deployed with Nixops";
   host        = "www.${self.domain}";
   adminEmail  = "admin@${self.host}";
 
@@ -18,6 +19,11 @@ in lib.makeExtensible (self: {
 
   # Configure timezone settings (http://php.net/manual/en/timezones.php)
   timezone  = "UTC";
+
+  # WP-CLI settings for automatic install
+  autoInstall   = false;
+  adminUser     = (import ./wordpress-admin.keys.nix).adminUser;
+  adminPassword = (import ./wordpress-admin.keys.nix).adminPassword;
 
   wordpress = import ./wordpress.nix;
   plugins   = import ./plugins.nix;

--- a/wordpress-admin.keys.nix.sample
+++ b/wordpress-admin.keys.nix.sample
@@ -1,0 +1,5 @@
+{
+  # Configure credentials for the superadmin in Wordpress
+  adminUser = "...";
+  adminPassword = "...";
+}

--- a/wp-config.nix
+++ b/wp-config.nix
@@ -19,7 +19,7 @@
   ${extraConfig}
 
   define('WP_DEBUG', ${if debugMode then "true" else "false"});
-
-  define('ABSPATH', dirname(__FILE__) . '/');
+  if ( !defined('ABSPATH') )
+    define('ABSPATH', dirname(__FILE__) . '/');
   require_once(ABSPATH . 'wp-settings.php');
 ''


### PR DESCRIPTION
@3noch This is what I have so far that fixes #3. I'm happy to receive feedback! Inspired by your help in the issue discussion.

* I've added the required inputs for the install to default-app-config.nix
* The systemd service is working both on new and redeploys. It can be turned on or off.
* The password for the superadmin in WP is visible via `systemctl status wp-cli`. I'm not really sure how to get around that. Reading from a file instead maybe.
* I also had to make a small modification to wp-config to remove a nagging PHP notice message during install.



```bash
wordpress-main systemd[1]: Starting WP-CLI for WordPress...
wordpress-main wp[1998]: Success: WordPress installed successfully.
wordpress-main wp[2012]: Success: Updated 'blogdescription' option.
```
```bash
wordpress-main systemd[1]: Starting WP-CLI for WordPress...
wordpress-main wp[3199]: WordPress is already installed.
wordpress-main wp[3249]: Success: Value passed for 'blogdescription' option is unchanged.
```